### PR TITLE
The adapter that supports multi-frame Cfg

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ sources:
   - src/xdma_req_backend.sv
   - src/xdma_axi_adapter_top.sv
 
-  - target: test
+  - target: xdma_axi_adapter_test
     files:
       - test/tb_find_first_one_idx.sv
       - test/tb_xdma_meta_manager.sv

--- a/src/xdma_axi_adapter_top.sv
+++ b/src/xdma_axi_adapter_top.sv
@@ -16,47 +16,35 @@ module xdma_axi_adapter_top
   import xdma_pkg::*;
 #(
     // AXI types
-    parameter type axi_id_t                            = logic,
-    parameter type axi_out_req_t                       = logic,
-    parameter type axi_out_resp_t                      = logic,
-    parameter type axi_in_req_t                        = logic,
-    parameter type axi_in_resp_t                       = logic,
+    parameter type axi_id_t             = logic,
+    parameter type axi_out_req_t        = logic,
+    parameter type axi_out_resp_t       = logic,
+    parameter type axi_in_req_t         = logic,
+    parameter type axi_in_resp_t        = logic,
     // Reqrsp types
-    parameter type reqrsp_req_t                        = logic,
-    parameter type reqrsp_rsp_t                        = logic,
+    parameter type reqrsp_req_t         = logic,
+    parameter type reqrsp_rsp_t         = logic,
     // Data types
-    parameter type data_t                              = logic,
-    parameter type strb_t                              = logic,
-    parameter type addr_t                              = logic,
+    parameter type data_t               = logic,
+    parameter type strb_t               = logic,
+    parameter type addr_t               = logic,
     // XDMA type
     // Total dma length type
-    parameter type len_t                               = logic,
+    parameter type len_t                = logic,
     // Sender side
-    parameter type xdma_to_remote_cfg_t                = logic,
+    parameter type xdma_to_remote_cfg_t = logic,
     // typedef struct packed {
-    //     id_t                                     dma_id; 
-    //     // The dma_type
-    //     // 0: read
-    //     // 1: write
-    //     logic                                    dma_type;
-    //     // The reader addr indicates the source of data
-    //     addr_t                                   reader_addr;
-    //     xdma_inter_cluster_cfg_broadcast_t       writer_addr;
-    //     stride_t                                 spatial_stride;
-    //     xdma_inter_cluster_cfg_temporal_bound_t  temporal_bound;
-    //     xdma_inter_cluster_cfg_temporal_stride_t temporal_stride;
-    //     enable_channel_t                         enable_channel;
-    //     enable_byte_t                            enable_byte;
-    // } xdma_inter_cluster_cfg__t;
-    /// - dma_id:
-    /// - dma_type:
-    /// - reader_addr:
-    /// - writer_addr:
-    /// - spatial_stride:
-    /// - temporal_bound:
-    /// - temporal_stride:
-    /// - enable_channel:
-    /// - enable_byte:
+    //   first_frame_remaining_payload_t first_frame_remaining_payload;
+    //   addr_t                          writer_addr;
+    //   addr_t                          reader_addr;
+
+    //   id_t           dma_id;
+    //   frame_length_t frame_length;
+    //   // The dma_type
+    //   // 0: read
+    //   // 1: write
+    //   logic          dma_type;
+    // } xdma_inter_cluster_first_cfg_t;
     parameter type xdma_to_remote_data_t               = logic,
     /// The data is logic [DataWidth-1:0]
     parameter type xdma_to_remote_data_accompany_cfg_t = logic,
@@ -83,39 +71,36 @@ module xdma_axi_adapter_top
     ///     len_t                                dma_length;
     ///     logic                                ready_to_transfer;
     /// } xdma_req_desc_t;
-    parameter type xdma_req_meta_t                       = logic,
+    parameter type xdma_req_meta_t          = logic,
     /// typedef struct packed {
     ///     id_t                                 dma_id;
     ///     len_t                                dma_length;
     /// } xdma_req_meta_t;       
-    parameter type xdma_to_remote_grant_t                = logic,
+    parameter type xdma_to_remote_grant_t   = logic,
     // typedef struct packed {
     //     id_t                                 dma_id;
     //     addr_t                               from;
     //     grant_reserved_t                     reserved;
     // } xdma_to_remote_grant_t;
     // Receiver side
-    parameter type xdma_from_remote_grant_t              = logic,
+    parameter type xdma_from_remote_grant_t = logic,
     // typedef struct packed {
     //     id_t                                 dma_id;
     //     addr_t                               from;
     // } xdma_from_remote_grant_t;    
-    parameter type xdma_from_remote_cfg_t                = logic,
+    parameter type xdma_from_remote_cfg_t   = logic,
     // typedef struct packed {
-    //     id_t                                     dma_id; 
-    //     // The dma_type
-    //     // 0: read
-    //     // 1: write
-    //     logic                                    dma_type;
-    //     // The reader addr indicates the source of data
-    //     addr_t                                   reader_addr;
-    //     xdma_inter_cluster_cfg_broadcast_t       writer_addr;
-    //     stride_t                                 spatial_stride;
-    //     xdma_inter_cluster_cfg_temporal_bound_t  temporal_bound;
-    //     xdma_inter_cluster_cfg_temporal_stride_t temporal_stride;
-    //     enable_channel_t                         enable_channel;
-    //     enable_byte_t                            enable_byte;
-    // } xdma_inter_cluster_cfg__t;
+    //   first_frame_remaining_payload_t first_frame_remaining_payload;
+    //   addr_t                          writer_addr;
+    //   addr_t                          reader_addr;
+
+    //   id_t           dma_id;
+    //   frame_length_t frame_length;
+    //   // The dma_type
+    //   // 0: read
+    //   // 1: write
+    //   logic          dma_type;
+    // } xdma_inter_cluster_first_cfg_t;
     parameter type xdma_from_remote_data_t               = logic,
     /// The data is logic [DataWidth-1:0]
     parameter type xdma_from_remote_data_accompany_cfg_t = logic,
@@ -212,6 +197,8 @@ module xdma_axi_adapter_top
   // Descriptions
   xdma_req_desc_t
       to_remote_cfg_desc, to_remote_data_desc, to_remote_grant_desc, to_remote_finish_desc;
+  // CFG ready to transfer signal
+  logic cfg_ready_to_transfer;
   always_comb begin : proc_unpack_desc
     //--------------------------------------
     // to remote cfg desc
@@ -228,13 +215,14 @@ module xdma_axi_adapter_top
     to_remote_cfg_desc.remote_addr         = (to_remote_cfg_desc.dma_type == 1'b0)
                                                ? (to_remote_cfg_i.reader_addr >= MainMemBaseAddr) ? MainMemEndAddr-MMIOCFGOffset : get_cluster_end_addr(
         to_remote_cfg_i.reader_addr) - MMIOCFGOffset :
-        (to_remote_cfg_i.writer_addr.write_addr_0 >= MainMemBaseAddr) ?
+        (to_remote_cfg_i.writer_addr >= MainMemBaseAddr) ?
         MainMemEndAddr - MMIOCFGOffset :
-        get_cluster_end_addr(to_remote_cfg_i.writer_addr.write_addr_0) - MMIOCFGOffset;
-    // Now we assume there are only one 512bit cfg
-    to_remote_cfg_desc.dma_length = 1;
-    // Ready to transfer
-    to_remote_cfg_desc.ready_to_transfer = to_remote_cfg_valid_i;
+        get_cluster_end_addr(to_remote_cfg_i.writer_addr) - MMIOCFGOffset;
+    // The cfg length is stored in the first frame.
+    to_remote_cfg_desc.dma_length = to_remote_cfg_i.frame_length;
+    // Ready to transfer logic: Is a FSM that counts the frames to determine the frame header
+    // FSM will control cfg_ready_to_transfer signal when the first frame is there
+    to_remote_cfg_desc.ready_to_transfer = cfg_ready_to_transfer;
 
     //--------------------------------------
     // to remote data desc
@@ -272,7 +260,73 @@ module xdma_axi_adapter_top
 
   end
 
+  // FSM to control the cfg_ready_to_transfer signal
+  typedef enum int unsigned {
+    sIDLE = 0,
+    sSendFrameBody = 1
+  } state_cfg_ready_to_transfer_t;
 
+  // Declaration of the FSM's current and next state
+  state_cfg_ready_to_transfer_t cur_state_cfg_ready_to_transfer, next_state_ready_to_transfer;
+
+  // Declaration of the counter reg that count the current cfg frame number
+  frame_length_t frame_length_counter;
+  logic frame_length_counter_enable, frame_length_counter_clear;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      frame_length_counter <= '0;
+    end else if (frame_length_counter_clear) begin
+      frame_length_counter <= '0;
+    end else if (frame_length_counter_enable) begin
+      frame_length_counter <= frame_length_counter + 1;
+    end
+  end
+
+  // Declaration of the holder reg that hold the cfg total length
+  frame_length_t frame_length_holder;
+  logic frame_length_holder_enable;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      frame_length_holder <= '0;
+    end else if (frame_length_holder_enable) begin
+      frame_length_holder <= to_remote_cfg_desc.dma_length;
+    end
+  end
+
+  // Current State Logic
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cur_state_cfg_ready_to_transfer <= sIDLE;
+    end else begin
+      cur_state_cfg_ready_to_transfer <= next_state_ready_to_transfer;
+    end
+  end
+
+  // Next State Logic
+  always_comb begin : proc_next_state_logic
+    cfg_ready_to_transfer = 1'b0;
+    frame_length_counter_clear = 1'b0;
+    frame_length_counter_enable = to_remote_cfg_valid_i && to_remote_cfg_ready_o;
+    frame_length_holder_enable = 1'b0;
+    next_state_ready_to_transfer = cur_state_cfg_ready_to_transfer;
+    case (cur_state_cfg_ready_to_transfer)
+      sIDLE: begin
+        cfg_ready_to_transfer = to_remote_cfg_valid_i;
+        frame_length_counter_clear = 1'b1;
+        if (to_remote_cfg_valid_i && to_remote_cfg_ready_o && to_remote_cfg_desc.dma_length > 1) begin
+          // When the first frame is acknowledged, and the length is larger than 1, then the remaining several frames are not the header, so should not commit the new transfer
+          frame_length_counter_clear = 1'b0;
+          frame_length_holder_enable = 1'b1;
+          next_state_ready_to_transfer = sSendFrameBody;
+        end
+      end
+      sSendFrameBody: begin
+        if (frame_length_counter == frame_length_holder - 1) begin
+          next_state_ready_to_transfer = sIDLE;
+        end
+      end
+    endcase
+  end
 
   //--------------------------------------
   // Req Manager

--- a/src/xdma_axi_adapter_top.sv
+++ b/src/xdma_axi_adapter_top.sv
@@ -49,19 +49,13 @@ module xdma_axi_adapter_top
     /// The data is logic [DataWidth-1:0]
     parameter type xdma_to_remote_data_accompany_cfg_t = logic,
     /// typedef struct packed {
-    ///     id_t                                 dma_id; 
+    ///     id_t                                 dma_id;
     ///     logic                                dma_type;
     ///     addr_t                               src_addr;
     ///     addr_t                               dst_addr;
     ///     len_t                                dma_length;
     ///     logic                                ready_to_transfer;
     /// } xdma_accompany_cfg_t;
-    /// - dma_id:
-    /// - dma_type:
-    /// - src_addr:
-    /// - dst_addr:
-    /// - dma_length:
-    /// - ready_to_transfer:
     parameter type xdma_req_desc_t                     = logic,
 
     /// typedef struct packed {
@@ -87,7 +81,7 @@ module xdma_axi_adapter_top
     // typedef struct packed {
     //     id_t                                 dma_id;
     //     addr_t                               from;
-    // } xdma_from_remote_grant_t;    
+    // } xdma_from_remote_grant_t;
     parameter type xdma_from_remote_cfg_t   = logic,
     // typedef struct packed {
     //   first_frame_remaining_payload_t first_frame_remaining_payload;
@@ -111,7 +105,7 @@ module xdma_axi_adapter_top
     //     addr_t                               dst_addr;
     //     len_t                                dma_length;
     //     logic                                ready_to_transfer;
-    // } xdma_accompany_cfg_t;    
+    // } xdma_accompany_cfg_t;
 
     // Cluster Cfgs
     parameter addr_t ClusterBaseAddr     = 'h1000_0000,
@@ -215,8 +209,7 @@ module xdma_axi_adapter_top
     to_remote_cfg_desc.remote_addr         = (to_remote_cfg_desc.dma_type == 1'b0)
                                                ? (to_remote_cfg_i.reader_addr >= MainMemBaseAddr) ? MainMemEndAddr-MMIOCFGOffset : get_cluster_end_addr(
         to_remote_cfg_i.reader_addr) - MMIOCFGOffset :
-        (to_remote_cfg_i.writer_addr >= MainMemBaseAddr) ?
-        MainMemEndAddr - MMIOCFGOffset :
+        (to_remote_cfg_i.writer_addr >= MainMemBaseAddr) ? MainMemEndAddr - MMIOCFGOffset :
         get_cluster_end_addr(to_remote_cfg_i.writer_addr) - MMIOCFGOffset;
     // The cfg length is stored in the first frame.
     to_remote_cfg_desc.dma_length = to_remote_cfg_i.frame_length;
@@ -315,8 +308,8 @@ module xdma_axi_adapter_top
         frame_length_counter_clear = 1'b1;
         if (to_remote_cfg_valid_i && to_remote_cfg_ready_o && to_remote_cfg_desc.dma_length > 1) begin
           // When the first frame is acknowledged, and the length is larger than 1, then the remaining several frames are not the header, so should not commit the new transfer
-          frame_length_counter_clear = 1'b0;
-          frame_length_holder_enable = 1'b1;
+          frame_length_counter_clear   = 1'b0;
+          frame_length_holder_enable   = 1'b1;
           next_state_ready_to_transfer = sSendFrameBody;
         end
       end
@@ -324,6 +317,9 @@ module xdma_axi_adapter_top
         if (frame_length_counter == frame_length_holder - 1) begin
           next_state_ready_to_transfer = sIDLE;
         end
+      end
+      default: begin
+        next_state_ready_to_transfer = sIDLE;
       end
     endcase
   end
@@ -603,7 +599,7 @@ module xdma_axi_adapter_top
 
   //-------------------------------------
   // Finish Manager
-  //-------------------------------------  
+  //-------------------------------------
   logic  from_remote_data_happening;
   addr_t remote_addr;
   id_t   from_remote_dma_id;

--- a/src/xdma_pkg.sv
+++ b/src/xdma_pkg.sv
@@ -33,6 +33,7 @@ package xdma_pkg;
   localparam int unsigned FirstFrameRemaingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth - DMAIdWidth - AddrWidth - AddrWidth;
   typedef logic [FirstFrameRemaingPayloadWidth-1:0] first_frame_remaining_payload_t;
   localparam int unsigned RemainingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth;
+  typedef logic [RemainingPayloadWidth-1:0] remaining_payload_t;
 
   //--------------------------------------
   // to remote cfg type

--- a/src/xdma_pkg.sv
+++ b/src/xdma_pkg.sv
@@ -5,6 +5,7 @@
 //! XDMA Package
 /// Contains all necessary type definitions, constants, and generally useful functions.
 package xdma_pkg;
+  localparam int unsigned DMAIdWidth = 32'd4;
   localparam int unsigned AxiDataWidth = 32'd512;
   localparam int unsigned StrbWidth = AxiDataWidth / 8;
   localparam int unsigned AddrWidth = 32'd48;
@@ -15,6 +16,7 @@ package xdma_pkg;
   localparam int unsigned DMALengthWidth = 32'd19;
   // localparam int unsigned NrBroadcast  = 32'd4;
   // localparam int unsigned NrDimension = 32'd6;
+  typedef logic [DMAIdWidth-1:0] id_t;
   typedef logic [AxiDataWidth-1:0] data_t;
   typedef logic [StrbWidth-1:0] strb_t;
   typedef logic [AddrWidth-1:0] addr_t;
@@ -26,11 +28,8 @@ package xdma_pkg;
   typedef logic [AxiDataWidth-DMAIdWidth-AddrWidth-1:0] grant_reserved_t;
   typedef logic [AxiDataWidth-DMAIdWidth-AddrWidth-1:0] finish_reserved_t;
 
-
   localparam int unsigned TotalFrameWidth = 32'd4;
   typedef logic [TotalFrameWidth-1:0] frame_length_t;
-  localparam int unsigned DMAIdWidth = 32'd4;
-  typedef logic [DMAIdWidth-1:0] id_t;
   localparam int unsigned FirstFrameRemaingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth - DMAIdWidth - AddrWidth - AddrWidth;
   typedef logic [FirstFrameRemaingPayloadWidth-1:0] first_frame_remaining_payload_t;
   localparam int unsigned RemainingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth;

--- a/src/xdma_pkg.sv
+++ b/src/xdma_pkg.sv
@@ -7,68 +7,82 @@
 package xdma_pkg;
   localparam int unsigned AxiDataWidth = 32'd512;
   localparam int unsigned StrbWidth = AxiDataWidth / 8;
-  localparam int unsigned DMAIdWidth = 32'd8;
   localparam int unsigned AddrWidth = 32'd48;
   localparam int unsigned StrideWidth = 32'd19;
   localparam int unsigned BoundWidth = 32'd19;
-  localparam int unsigned EnableChannelWidth = 32'd8;
-  localparam int unsigned EnableByteWidth = 32'd8;
+  // localparam int unsigned EnableChannelWidth = 32'd8;
+  // localparam int unsigned EnableByteWidth = 32'd8;
   localparam int unsigned DMALengthWidth = 32'd19;
-  localparam int unsigned NrBroadcast = 32'd4;
-  localparam int unsigned NrDimension = 32'd6;
+  // localparam int unsigned NrBroadcast  = 32'd4;
+  // localparam int unsigned NrDimension = 32'd6;
   typedef logic [AxiDataWidth-1:0] data_t;
   typedef logic [StrbWidth-1:0] strb_t;
-  typedef logic [DMAIdWidth-1:0] id_t;
   typedef logic [AddrWidth-1:0] addr_t;
-  typedef logic [StrideWidth-1:0] stride_t;
-  typedef logic [BoundWidth-1:0] bound_t;
-  typedef logic [EnableChannelWidth-1:0] enable_channel_t;
-  typedef logic [EnableByteWidth-1:0] enable_byte_t;
+  // typedef logic [StrideWidth-1:0] stride_t;
+  // typedef logic [BoundWidth-1:0] bound_t;
+  // typedef logic [EnableChannelWidth-1:0] enable_channel_t;
+  // typedef logic [EnableByteWidth-1:0] enable_byte_t;
   typedef logic [DMALengthWidth-1:0] len_t;
   typedef logic [AxiDataWidth-DMAIdWidth-AddrWidth-1:0] grant_reserved_t;
   typedef logic [AxiDataWidth-DMAIdWidth-AddrWidth-1:0] finish_reserved_t;
 
+
+  localparam int unsigned TotalFrameWidth = 32'd4;
+  typedef logic [TotalFrameWidth-1:0] frame_length_t;
+  localparam int unsigned DMAIdWidth = 32'd4;
+  typedef logic [DMAIdWidth-1:0] id_t;
+  localparam int unsigned FirstFrameRemaingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth - DMAIdWidth - AddrWidth - AddrWidth;
+  typedef logic [FirstFrameRemaingPayloadWidth-1:0] first_frame_remaining_payload_t;
+  localparam int unsigned RemainingPayloadWidth = AxiDataWidth - 1 - TotalFrameWidth;
+
   //--------------------------------------
   // to remote cfg type
   //--------------------------------------
-  typedef struct packed {
-    addr_t write_addr_3;
-    addr_t write_addr_2;
-    addr_t write_addr_1;
-    addr_t write_addr_0;
-  } xdma_inter_cluster_cfg_broadcast_t;
+  // typedef struct packed {
+  //   addr_t write_addr_3;
+  //   addr_t write_addr_2;
+  //   addr_t write_addr_1;
+  //   addr_t write_addr_0;
+  // } xdma_inter_cluster_cfg_broadcast_t;
+
+  // typedef struct packed {
+  //   bound_t temporal_bound_5;
+  //   bound_t temporal_bound_4;
+  //   bound_t temporal_bound_3;
+  //   bound_t temporal_bound_2;
+  //   bound_t temporal_bound_1;
+  //   bound_t temporal_bound_0;
+  // } xdma_inter_cluster_cfg_temporal_bound_t;
+
+  // typedef struct packed {
+  //   stride_t temporal_stride_5;
+  //   stride_t temporal_stride_4;
+  //   stride_t temporal_stride_3;
+  //   stride_t temporal_stride_2;
+  //   stride_t temporal_stride_1;
+  //   stride_t temporal_stride_0;
+  // } xdma_inter_cluster_cfg_temporal_stride_t;
 
   typedef struct packed {
-    bound_t temporal_bound_5;
-    bound_t temporal_bound_4;
-    bound_t temporal_bound_3;
-    bound_t temporal_bound_2;
-    bound_t temporal_bound_1;
-    bound_t temporal_bound_0;
-  } xdma_inter_cluster_cfg_temporal_bound_t;
+    first_frame_remaining_payload_t first_frame_remaining_payload;
+    addr_t                          writer_addr;
+    addr_t                          reader_addr;
 
-  typedef struct packed {
-    stride_t temporal_stride_5;
-    stride_t temporal_stride_4;
-    stride_t temporal_stride_3;
-    stride_t temporal_stride_2;
-    stride_t temporal_stride_1;
-    stride_t temporal_stride_0;
-  } xdma_inter_cluster_cfg_temporal_stride_t;
-
-  typedef struct packed {
-    enable_byte_t                            enable_byte;
-    enable_channel_t                         enable_channel;
-    xdma_inter_cluster_cfg_temporal_stride_t temporal_stride;
-    xdma_inter_cluster_cfg_temporal_bound_t  temporal_bound;
-    stride_t                                 spatial_stride;
-    xdma_inter_cluster_cfg_broadcast_t       writer_addr;
-    addr_t                                   reader_addr;
+    id_t           dma_id;
+    frame_length_t frame_length;
     // The dma_type
     // 0: read
     // 1: write
-    logic                                    dma_type;
-    id_t                                     dma_id;
+    logic          dma_type;
+  } xdma_inter_cluster_first_cfg_t;
+
+  typedef struct packed {
+    remaining_payload_t remaining_payload;
+    // The dma_type
+    // 0: read
+    // 1: write
+    logic               dma_type;
+    id_t                dma_id;
   } xdma_inter_cluster_cfg_t;
 
   typedef logic [AxiDataWidth-1:0] xdma_to_remote_data_t;

--- a/src/xdma_pkg.sv
+++ b/src/xdma_pkg.sv
@@ -38,30 +38,6 @@ package xdma_pkg;
   //--------------------------------------
   // to remote cfg type
   //--------------------------------------
-  // typedef struct packed {
-  //   addr_t write_addr_3;
-  //   addr_t write_addr_2;
-  //   addr_t write_addr_1;
-  //   addr_t write_addr_0;
-  // } xdma_inter_cluster_cfg_broadcast_t;
-
-  // typedef struct packed {
-  //   bound_t temporal_bound_5;
-  //   bound_t temporal_bound_4;
-  //   bound_t temporal_bound_3;
-  //   bound_t temporal_bound_2;
-  //   bound_t temporal_bound_1;
-  //   bound_t temporal_bound_0;
-  // } xdma_inter_cluster_cfg_temporal_bound_t;
-
-  // typedef struct packed {
-  //   stride_t temporal_stride_5;
-  //   stride_t temporal_stride_4;
-  //   stride_t temporal_stride_3;
-  //   stride_t temporal_stride_2;
-  //   stride_t temporal_stride_1;
-  //   stride_t temporal_stride_0;
-  // } xdma_inter_cluster_cfg_temporal_stride_t;
 
   typedef struct packed {
     first_frame_remaining_payload_t first_frame_remaining_payload;
@@ -100,14 +76,6 @@ package xdma_pkg;
     ToRemoteData   = 3,
     NUM_INP = 4
   } xdma_to_remote_idx_e;
-
-  // typedef enum int unsigned {
-  //     ToRemoteCfg  = 0,
-  //     ToRemoteData = 1,
-  //     ToRemoteGrant= 2,
-  //     NUM_INP = 3
-  // } xdma_to_remote_idx_e;
-
 
   typedef logic [$clog2(NUM_INP)-1:0] xdma_req_idx_t;
   //--------------------------------------

--- a/src/xdma_pkg.sv
+++ b/src/xdma_pkg.sv
@@ -67,23 +67,22 @@ package xdma_pkg;
     first_frame_remaining_payload_t first_frame_remaining_payload;
     addr_t                          writer_addr;
     addr_t                          reader_addr;
-
-    id_t           dma_id;
-    frame_length_t frame_length;
+    id_t                            dma_id;
+    frame_length_t                  frame_length;
     // The dma_type
     // 0: read
     // 1: write
-    logic          dma_type;
-  } xdma_inter_cluster_first_cfg_t;
-
-  typedef struct packed {
-    remaining_payload_t remaining_payload;
-    // The dma_type
-    // 0: read
-    // 1: write
-    logic               dma_type;
-    id_t                dma_id;
+    logic                           dma_type;
   } xdma_inter_cluster_cfg_t;
+
+  // typedef struct packed {
+  //   remaining_payload_t remaining_payload;
+  //   // The dma_type
+  //   // 0: read
+  //   // 1: write
+  //   logic               dma_type;
+  //   id_t                dma_id;
+  // } xdma_inter_cluster_cfg_t;
 
   typedef logic [AxiDataWidth-1:0] xdma_to_remote_data_t;
   typedef logic [AxiDataWidth-1:0] xdma_from_remote_data_t;


### PR DESCRIPTION
This PR modifies the adapter to support reading the frame length from cfg, being able to forward cfg up to 15 frames. 

The testbench has not been modified, as now chip infrastructure is enough for the test. The testbench is excluded from compilation.
